### PR TITLE
Allow dashes in variable names

### DIFF
--- a/syntaxes/clips.tmLanguage.json
+++ b/syntaxes/clips.tmLanguage.json
@@ -35,7 +35,7 @@
           "name": "variable.other.object"
         },
         {
-          "match": "(\\$)?(\\?)[a-zA-Z0-9_]*",
+          "match": "(\\$)?(\\?)[a-zA-Z0-9_-]*",
           "name": "variable.language"
         },
         {


### PR DESCRIPTION
Clips allows for the kebab-case convention in variable names, and it is the suggested convention in the Clips user manual in the download section of the website. With this  commit the plugin recognizes dash separated word in a single variable name as a unique token, so that kebab-case variable names are highlighted correctly.